### PR TITLE
Recreate logger upon configuration change

### DIFF
--- a/logging/config/dynamic.go
+++ b/logging/config/dynamic.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/kyma-project/manager-toolkit/logging/logger"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 // ReconfigureOnConfigChange monitors config changes and updates log level and format dynamically.
@@ -14,12 +13,17 @@ import (
 func ReconfigureOnConfigChange(ctx context.Context, log *zap.SugaredLogger, atomicLevel zap.AtomicLevel, cfgPath string) {
 	RunOnConfigChange(ctx, log, cfgPath, func(cfg Config) {
 		// Update log level
-		level, err := zapcore.ParseLevel(cfg.LogLevel)
+		level, err := logger.MapLevel(cfg.LogLevel)
 		if err != nil {
 			log.Error(err)
 			return
 		}
-		atomicLevel.SetLevel(level)
+		zapLevel, err := level.ToZapLevel()
+		if err != nil {
+			log.Error(err)
+			return
+		}
+		atomicLevel.SetLevel(zapLevel)
 
 		// Recreate logger with current format from config
 		format, err := logger.MapFormat(cfg.LogFormat)


### PR DESCRIPTION
**Description**
Recreating the logger happens so fast that the simpliest solution should be to just always recreate it

**Related issue(s)**
https://github.com/kyma-project/serverless/issues/2005#issuecomment-3718523604
